### PR TITLE
Removed Scrapyard Cleveland, added Hack The Land

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ And thank you for your help!
 * [NOARSfest](https://www.noars.net/?page_id=137) presented by The Northern Ohio Amateur Radio Society
 * [CWRU [You]Tech Conference](https://case.edu/utech/youtech-conference-2019)
 * [Futureland](https://www.futurelandcle.com/)
-* [Scrapyard Cleveland](https://scrapyardcle.org/)
+* [Hack The Land](https://hacktheland.xyz)
 
 ## Job Search Sites
 


### PR DESCRIPTION
Removed Scrapyard Cleveland due it concluding March 15th (and not reoccuring) 

Added the successor aka Hack The Land which will hopefully be annual!